### PR TITLE
Fix TextSub crash that could occur in rare circumstances

### DIFF
--- a/src/filters/transform/vsfilter/plugins.cpp
+++ b/src/filters/transform/vsfilter/plugins.cpp
@@ -295,6 +295,7 @@ public:
 						fn = fn2;
 						handles.SetCount(1);
 						handles.Add(h);
+						CFileGetStatus(fn, fs);
 					}
 				}
 			}


### PR DESCRIPTION
Although I was unable to determine the exact set of conditions which
triggered this crash, I was able to reproduce it with a specific set of
ASS files, when writing the output video to the same directory that
contained the input files.

The crash was occurring in XyAtlMap::RemoveAll when reloading the sub
stream, which was triggered unnecessarily on plugins.cpp:277, because
the `fs` object was still fully zeroed, and was never updated in the
WAIT_TIMEOUT block in which the file was lazily initialized, but change
notifications were triggering as a result of file access time updates.
By properly updating the file info when lazily initializing the file
handle, we avoid triggering the reload which crashes VSFilter.