### PR TITLE
fix scale between subtitle and video on CWord

### DIFF
--- a/src/subtitles/RTS.h
+++ b/src/subtitles/RTS.h
@@ -84,6 +84,7 @@ protected:
 public:
     // str[0] = 0 -> m_fLineBreak = true (in this case we only need and use the height of m_font from the whole class)
     CWord(const FwSTSStyle& style, const CStringW& str, int ktype, int kstart, int kend
+        , double scalex, double scaley
         , double target_scale_x=1.0, double target_scale_y=1.0
         , bool round_to_whole_pixel_after_scale_to_target = false);
     CWord(const CWord&);
@@ -108,6 +109,7 @@ public:
     SharedPtrCPolygon m_pOpaqueBox;
     int               m_ktype, m_kstart, m_kend;
     int               m_width, m_ascent, m_descent;
+    double            m_scalex, m_scaley;
     double            m_target_scale_x, m_target_scale_y;
     bool              m_round_to_whole_pixel_after_scale_to_target;//it is necessary to avoid some artifacts
 
@@ -134,6 +136,7 @@ protected:
     static void GetTextInfo(TextInfo *output, const FwSTSStyle& style, const CStringW& str);
 public:
     CText(const FwSTSStyle& style, const CStringW& str, int ktype, int kstart, int kend
+        , double scalex, double scaley
         , double target_scale_x=1.0, double target_scale_y=1.0);
     CText(const CText& src);
 
@@ -148,7 +151,6 @@ class CPolygon : public CWord
     bool ParseStr();
 
 protected:
-    double            m_scalex, m_scaley;
     int               m_baseline;
     CAtlArray<BYTE>   m_pathTypesOrg;
     CAtlArray<CPoint> m_pathPointsOrg;


### PR DESCRIPTION
xy-VSFilter has two scales, scale* handles scale between subtitle and video, target_scale_* handles scale between video and output rect.
This PR means to handle scale* on CWord, which is mainly used on function Transform, and fix #17 .