### PR TITLE
ASS Format: Introduce LayoutRes{X,Y} script headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,91 @@
+name: Build VSFilter
+
+on:
+  push:
+    branches: [ci, xy_sub_filter_rc*, vsfilter_rc*, master]
+
+jobs:
+  build:
+    runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - msarch: x64
+            vsfplat: x64
+            namesuf: x86-64
+          - arch: x86
+            vsfplat: Win32
+            namesuf: x86-32
+    defaults:
+      run:
+        shell: 'bash'
+
+    steps:
+      - name: Determine configuration
+        id: config
+        run: |
+          # base name of GHA artifact
+          name="VSFilter+SubFilter"
+          # space delimited list of filename stems to delete from artifact
+          delete=""
+
+          # If it runs for one of the main XySubFilter or xy-VSFilter dev branches,
+          # only publish compatible binaries. If it's some other branch, it's probably
+          # a transient testing build, so keep everything.
+          # ref.: https://github.com/Cyberbeing/xy-VSFilter/pull/18#issuecomment-1302638201
+          REF="${{ github.ref }}"
+          REF="${REF#refs/heads/}"
+          if [ "$REF" = "master" ] || [ "$REF" = "vsfilter_rc" ] ; then
+              name="VSFilter"
+              delete="XySubFilter"
+          # xy-VSFilter specific changes weren't merged back into the
+          # XySubFilter branch, so it normally shouldn't be used to build
+          # xy-VSFilter. But in pinterf/xy-VSFilter there’s only one branch.
+          #elif echo "$REF" | grep -qE '^xy_sub_filter_rc' ; then
+          #    name="SubFilter"
+          #    delete="VSFilter"
+          fi
+
+          echo "name=$name" >> $GITHUB_OUTPUT
+          echo "delete=$delete" >> $GITHUB_OUTPUT
+
+      - name: checkout code
+        uses: actions/checkout@v3
+        with:
+          # We need full history to allow finding the tag in build prep
+          fetch-depth: 0
+
+      - name: install yasm
+        shell: cmd
+        run: |
+          git clone --depth=1 https://github.com/ShiftMediaProject/VSYASM.git
+          .\VSYASM\install_script.bat
+
+      # VS2019 is 16.x;  VS2022 17.x
+      - name: Setup VS2019
+        uses: microsoft/setup-msbuild@v1.1
+        with:
+          msbuild-architecture: matrix.msarch
+      #    vs-version: '[16.01,16.11]'
+
+      - name: Build xy-VSFilter and/or XySubFilter
+        run: |
+          export VS160COMNTOOLS="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/Common7/Tools/"
+          bash ./build_vsfilter.sh -platform "${{ matrix.vsfplat }}" -compiler VS2019
+
+      - name: Prune incompatible files
+        if: steps.config.outputs.delete != ''
+        run: |
+          for dir in bin/lib*/*/Release ; do
+              for bn in ${{ steps.config.outputs.delete }} ; do
+                  rm -f "$dir"/"$bn".*
+              done
+          done
+
+      - name: Publish output
+        uses: actions/upload-artifact@v3
+        with:
+          name: xy-${{ steps.config.outputs.name }}_nightly_${{ matrix.namesuf }}
+          path: |
+            bin/lib*/*/Release

--- a/src/subtitles/RTS.cpp
+++ b/src/subtitles/RTS.cpp
@@ -1858,6 +1858,11 @@ bool CRenderedTextSubtitle::Init( const CRectCoor2& video_rect, const CRectCoor2
 {
     XY_LOG_INFO(_T(""));
     Deinit();
+
+    // Since this is only called from RenderEx(..), which already overrides
+    // original_video_size with m_layout_size when appropiate, we do not
+    // need to override it again and can just use original_size here
+
     m_video_rect = CRect(video_rect.left*MAX_SUB_PIXEL, 
                          video_rect.top*MAX_SUB_PIXEL, 
                          video_rect.right*MAX_SUB_PIXEL, 
@@ -3336,7 +3341,7 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx(SubPicDesc& spd, REFERENCE_TIME rt,
 
 STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame, int spd_type,
     const RECT& video_rect, const RECT& subtitle_target_rect,
-    const SIZE& original_video_size,
+    const SIZE& actual_original_video_size,
     REFERENCE_TIME rt, double fps )
 {
     TRACE_RENDERER_REQUEST("Begin RenderEx rt"<<rt);
@@ -3358,6 +3363,12 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame,
     {
         XY_LOG_WARN("FIXME: supported with hack");
         cvideo_rect.MoveToXY(0,0);
+    }
+
+    SIZE original_video_size = actual_original_video_size;
+    if (m_layout_size.cx > 0 && m_layout_size.cy > 0) {
+        original_video_size.cx = m_layout_size.cx;
+        original_video_size.cy = m_layout_size.cy;
     }
 
     XyColorSpace color_space = XY_CS_ARGB;

--- a/src/subtitles/RTS.cpp
+++ b/src/subtitles/RTS.cpp
@@ -1854,14 +1854,10 @@ void CRenderedTextSubtitle::OnChanged()
 
 
 bool CRenderedTextSubtitle::Init( const CRectCoor2& video_rect, const CRectCoor2& subtitle_target_rect,
-    const SIZE& original_video_size )
+    const SIZE& layout_size )
 {
     XY_LOG_INFO(_T(""));
     Deinit();
-
-    // Since this is only called from RenderEx(..), which already overrides
-    // original_video_size with m_layout_size when appropiate, we do not
-    // need to override it again and can just use original_size here
 
     m_video_rect = CRect(video_rect.left*MAX_SUB_PIXEL, 
                          video_rect.top*MAX_SUB_PIXEL, 
@@ -1869,12 +1865,12 @@ bool CRenderedTextSubtitle::Init( const CRectCoor2& video_rect, const CRectCoor2
                          video_rect.bottom*MAX_SUB_PIXEL);
     m_subtitle_target_rect = CRect(subtitle_target_rect.left*MAX_SUB_PIXEL, subtitle_target_rect.top*MAX_SUB_PIXEL, 
         subtitle_target_rect.right*MAX_SUB_PIXEL, subtitle_target_rect.bottom*MAX_SUB_PIXEL);
-    m_size = CSize(original_video_size.cx*MAX_SUB_PIXEL, original_video_size.cy*MAX_SUB_PIXEL);
+    m_size = CSize(layout_size.cx*MAX_SUB_PIXEL, layout_size.cy*MAX_SUB_PIXEL);
 
-    ASSERT(original_video_size.cx!=0 && original_video_size.cy!=0);
+    ASSERT(layout_size.cx!=0 && layout_size.cy!=0);
 
-    m_target_scale_x = video_rect.Width()  * 1.0 / original_video_size.cx;
-    m_target_scale_y = video_rect.Height() * 1.0 / original_video_size.cy;
+    m_target_scale_x = video_rect.Width()  * 1.0 / layout_size.cx;
+    m_target_scale_y = video_rect.Height() * 1.0 / layout_size.cy;
 
     return(true);
 }
@@ -3341,7 +3337,7 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx(SubPicDesc& spd, REFERENCE_TIME rt,
 
 STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame, int spd_type,
     const RECT& video_rect, const RECT& subtitle_target_rect,
-    const SIZE& actual_original_video_size,
+    const SIZE& original_video_size,
     REFERENCE_TIME rt, double fps )
 {
     TRACE_RENDERER_REQUEST("Begin RenderEx rt"<<rt);
@@ -3365,10 +3361,10 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame,
         cvideo_rect.MoveToXY(0,0);
     }
 
-    SIZE original_video_size = actual_original_video_size;
+    SIZE layout_size = original_video_size;
     if (m_layout_size.cx > 0 && m_layout_size.cy > 0) {
-        original_video_size.cx = m_layout_size.cx;
-        original_video_size.cy = m_layout_size.cy;
+        layout_size.cx = m_layout_size.cx;
+        layout_size.cy = m_layout_size.cy;
     }
 
     XyColorSpace color_space = XY_CS_ARGB;
@@ -3402,9 +3398,9 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame,
                                            subtitle_target_rect.top*MAX_SUB_PIXEL,
                                            subtitle_target_rect.right*MAX_SUB_PIXEL,
                                            subtitle_target_rect.bottom*MAX_SUB_PIXEL)
-        || m_size != CSize(original_video_size.cx*MAX_SUB_PIXEL, original_video_size.cy*MAX_SUB_PIXEL) )
+        || m_size != CSize(layout_size.cx*MAX_SUB_PIXEL, layout_size.cy*MAX_SUB_PIXEL) )
     {
-        if (!Init(cvideo_rect, subtitle_target_rect, original_video_size))
+        if (!Init(cvideo_rect, subtitle_target_rect, layout_size))
         {
             XY_LOG_FATAL("Failed to Init.");
             return E_FAIL;

--- a/src/subtitles/RTS.h
+++ b/src/subtitles/RTS.h
@@ -459,6 +459,8 @@ public:
 
 private:
     /*
+     * Expects the original_video_size parameter to already be
+     * overridden by LayoutRes headers when applicable.
      * Will call Deinit()
      */
     bool Init(const CRectCoor2& video_rect, const CRectCoor2& subtitle_target_rect,

--- a/src/subtitles/RTS.h
+++ b/src/subtitles/RTS.h
@@ -457,9 +457,13 @@ public:
     virtual void Copy(CSimpleTextSubtitle& sts);
     virtual void Empty();
 
-public:
+private:
+    /*
+     * Will call Deinit()
+     */
     bool Init(const CRectCoor2& video_rect, const CRectCoor2& subtitle_target_rect,
-        const SIZE& original_video_size); // will call Deinit()
+        const SIZE& original_video_size);
+public:
     void Deinit();
 
     DECLARE_IUNKNOWN

--- a/src/subtitles/RTS.h
+++ b/src/subtitles/RTS.h
@@ -459,12 +459,13 @@ public:
 
 private:
     /*
-     * Expects the original_video_size parameter to already be
-     * overridden by LayoutRes headers when applicable.
+     * The layout_size parameter is either derived from
+     * valid LayoutRes{X,Y} script headers (both must be valid!)
+     * or if those do not exist, equal to the video's storage resolution.
      * Will call Deinit()
      */
     bool Init(const CRectCoor2& video_rect, const CRectCoor2& subtitle_target_rect,
-        const SIZE& original_video_size);
+        const SIZE& layout_size);
 public:
     void Deinit();
 

--- a/src/subtitles/STS.cpp
+++ b/src/subtitles/STS.cpp
@@ -2060,6 +2060,16 @@ if(sver <= 4)   style->scrAlignment = (style->scrAlignment&4) ? ((style->scrAlig
                     : ret.m_dstScreenSize.cy * 4 / 3;
             }
         }
+        else if(entry == L"layoutresx")
+        {
+            try {ret.m_layout_size.cx = GetInt(buff);}
+            catch(...) {ret.m_layout_size = CSize(0, 0); return(false);}
+        }
+        else if(entry == L"layoutresy")
+        {
+            try {ret.m_layout_size.cy = GetInt(buff);}
+            catch(...) {ret.m_layout_size = CSize(0, 0); return(false);}
+        }
         else if(entry == L"wrapstyle")
         {
             try {ret.m_defaultWrapStyle = GetInt(buff);}

--- a/src/subtitles/STS.h
+++ b/src/subtitles/STS.h
@@ -180,6 +180,7 @@ public:
     int            m_defaultWrapStyle;
     int            m_collisions;
     bool           m_fScaledBAS;
+    CSize          m_layout_size;
 
     CSTSStyleMap   m_styles;
 

--- a/src/thirdparty/VirtualDub/Kasumi/Kasumi.vcxproj
+++ b/src/thirdparty/VirtualDub/Kasumi/Kasumi.vcxproj
@@ -39,6 +39,18 @@
     <Import Project="..\..\..\common.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ExecutablePath>$(VCInstallDir);$(VC_ExecutablePath_x86);$(CommonExecutablePath)</ExecutablePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ExecutablePath>$(VCInstallDir);$(VC_ExecutablePath_x86);$(CommonExecutablePath)</ExecutablePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ExecutablePath>$(VCInstallDir);$(VC_ExecutablePath_x64);$(CommonExecutablePath)</ExecutablePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ExecutablePath>$(VCInstallDir);$(VC_ExecutablePath_x64);$(CommonExecutablePath)</ExecutablePath>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>h;..\h;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/thirdparty/VirtualDub/system/system.vcxproj
+++ b/src/thirdparty/VirtualDub/system/system.vcxproj
@@ -39,6 +39,18 @@
     <Import Project="..\..\..\common.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ExecutablePath>$(VCInstallDir);$(VC_ExecutablePath_x86);$(CommonExecutablePath)</ExecutablePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ExecutablePath>$(VCInstallDir);$(VC_ExecutablePath_x86);$(CommonExecutablePath)</ExecutablePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ExecutablePath>$(VCInstallDir);$(VC_ExecutablePath_x64);$(CommonExecutablePath)</ExecutablePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ExecutablePath>$(VCInstallDir);$(VC_ExecutablePath_x64);$(CommonExecutablePath)</ExecutablePath>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>..\h;h;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
Backport of https://github.com/Cyberbeing/xy-VSFilter/pull/18 *(see also: https://github.com/Cyberbeing/xy-VSFilter/pull/19)*; the header was also introduced in libass and released as part of libass 0.17.0 about a month ago and clsid2 also works on implementing this in MPC-HC’s ISR.
In a sense also a follow up to #34.