### PR TITLE
Fix format list

### DIFF
--- a/src/dsutil/MediaTypes.cpp
+++ b/src/dsutil/MediaTypes.cpp
@@ -507,7 +507,7 @@ CString VIH2String(int i)
 {
 	CString ret = CString(GuidNames[*vihs[i].subtype]);
 	if(!ret.Left(13).CompareNoCase(_T("MEDIASUBTYPE_"))) ret = ret.Mid(13);
-	if(vihs[i].vih.bmiHeader.biCompression == 3) ret += _T(" BITF");
+	if(vihs[i].vih.bmiHeader.biCompression == BI_BITFIELDS) ret += _T(" BITF");
 	if(*vihs[i].subtype == MEDIASUBTYPE_I420) ret = _T("I420"); // FIXME
     else if(*vihs[i].subtype == MEDIASUBTYPE_NV21) ret = _T("NV21"); // FIXME
 	return(ret);

--- a/src/filters/transform/basevideofilter/BaseVideoFilter.cpp
+++ b/src/filters/transform/basevideofilter/BaseVideoFilter.cpp
@@ -89,7 +89,7 @@ CString OutputFmt2String(const OutputFormatBase& fmt)
 {
     CString ret = CString(GuidNames[*fmt.subtype]);
     if(!ret.Left(13).CompareNoCase(_T("MEDIASUBTYPE_"))) ret = ret.Mid(13);
-    if(fmt.biCompression == 3) ret += _T(" BITF");
+    if(fmt.biCompression == BI_BITFIELDS) ret += _T(" BITF");
     if(*fmt.subtype == MEDIASUBTYPE_I420) ret = _T("I420"); // FIXME
     else if(*fmt.subtype == MEDIASUBTYPE_NV21) ret = _T("NV21"); // FIXME
     return(ret);

--- a/src/filters/transform/vsfilter/DirectVobSubPropPage.cpp
+++ b/src/filters/transform/vsfilter/DirectVobSubPropPage.cpp
@@ -1451,7 +1451,7 @@ void CDVSColorPPage::UpdateControlData(bool fSave)
         m_outputFmtList.DeleteAllItems();
         m_outputFmtList.DeleteColumn(0);
         m_outputFmtList.SetExtendedStyle( (m_outputFmtList.GetStyle()|LVS_EX_CHECKBOXES) & ~LVS_EX_GRIDLINES );
-        m_outputFmtList.InsertColumn(0, _T("output"), LVCFMT_LEFT, 110);
+        m_outputFmtList.InsertColumn(0, _T("output"), LVCFMT_LEFT, 148);
         for(int i = 0; i < static_cast<int>(m_outputColorSpaceCount); i++)
         {
             m_outputFmtList.InsertItem(i, GetColorSpaceName(m_outputColorSpace[i].color_space,OUTPUT_COLOR_SPACE));


### PR DESCRIPTION
Increased the width of the format list column to accommodate the names of BITF formats.

Before:
<img width="266" height="226" alt="before" src="https://github.com/user-attachments/assets/b1a0040b-a0fa-4092-9628-de786fb3d73f" />

After:
<img width="266" height="226" alt="after" src="https://github.com/user-attachments/assets/0f41e12f-4f3f-43e7-b6d0-b341da08cff8" />
