### PR TITLE
Added support for top-down RGB video

### DIFF
--- a/src/filters/transform/basevideofilter/BaseVideoFilter.cpp
+++ b/src/filters/transform/basevideofilter/BaseVideoFilter.cpp
@@ -317,7 +317,7 @@ HRESULT hr1 = 0, hr2 = 0;
 			else // stupid overlay mixer won't let us know the new pitch...
 			{
 				long size = pOut->GetSize();
-				bmi->biWidth = size / bmi->biHeight * 8 / bmi->biBitCount;
+				bmi->biWidth = size / abs(bmi->biHeight) * 8 / bmi->biBitCount;
 			}
 		}
 		else
@@ -506,11 +506,12 @@ HRESULT CBaseVideoFilter::CheckInputType(const CMediaType* mtIn)
 {
 	BITMAPINFOHEADER bih;
 	ExtractBIH(mtIn, &bih);
-    
+
 	return mtIn->majortype == MEDIATYPE_Video 
 		&& GetInputSubtypePosition(mtIn->subtype)!=-1        
 		&& (mtIn->formattype == FORMAT_VideoInfo || mtIn->formattype == FORMAT_VideoInfo2)
-		&& bih.biHeight > 0
+		&& bih.biWidth > 0
+		&& bih.biHeight != 0
 		? S_OK
 		: VFW_E_TYPE_NOT_ACCEPTED;
 }

--- a/src/filters/transform/vsfilter/DirectVobSubFilter.cpp
+++ b/src/filters/transform/vsfilter/DirectVobSubFilter.cpp
@@ -180,7 +180,7 @@ void CDirectVobSubFilter::GetOutputSize(int& w, int& h, int& arx, int& ary)
 HRESULT CDirectVobSubFilter::TryNotCopy(IMediaSample* pIn, const CMediaType& mt, const BITMAPINFOHEADER& bihIn )
 {
     CSize sub(m_w, m_h);
-    CSize in(bihIn.biWidth, bihIn.biHeight);
+    CSize in(bihIn.biWidth, abs(bihIn.biHeight));
     BYTE* pDataIn = NULL;
     if(FAILED(pIn->GetPointer(&pDataIn)) || !pDataIn)
         return S_FALSE;
@@ -754,7 +754,7 @@ void CDirectVobSubFilter::InitSubPicQueue()
         m_pTempPicBuff.Allocate(m_spd.pitch*m_spd.h);
 	m_spd.bits = (BYTE*)m_pTempPicBuff;
 
-	CSize video(bihIn.biWidth, bihIn.biHeight), window = video;
+	CSize video(bihIn.biWidth, abs(bihIn.biHeight)), window = video;
 	if(AdjustFrameSize(window)) video += video;
 	ASSERT(window == CSize(m_w, m_h));
     CRect video_rect(CPoint((window.cx - video.cx)/2, (window.cy - video.cy)/2), video);


### PR DESCRIPTION
LAV Video Decoder outputs bottom-up RGB32/24 video (biCompression = BI_RGB, biHeight > 0).
[Newer versions of MPC Video Decoder](https://github.com/qwerttvv/Player/releases) output top-down RGB32 video (biCompression = BI_RGB, biHeight < 0). However, xy-VSFilter doesn't support this.

This change adds support for top-down RGB video.

[BITMAPINFOHEADER structure](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader)
>**biHeight**
>
>Specifies the height of the bitmap, in pixels.
>- For uncompressed RGB bitmaps, if biHeight is positive, the bitmap is a bottom-up DIB with the origin at the lower left corner. If biHeight is negative, the bitmap is a top-down DIB with the origin at the upper left corner.
>- For YUV bitmaps, the bitmap is always top-down, regardless of the sign of biHeight. Decoders should offer YUV formats with positive biHeight, but for backward compatibility they should accept YUV formats with either positive or negative biHeight.
>- For compressed formats, biHeight must be positive, regardless of image orientation.